### PR TITLE
Deprecate the lfs_content_path_to_git_root parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,11 @@ Add the following lines to your `conf.py`:
 extensions = [
     "sphinx_lfs_content",
 ]
-
-# The relative path from conf.py to the git repository root (defaults to ".")
-lfs_content_path_to_git_root = ".."
 ```
 
 That's all. The extension will check whether the system has `git-lfs` and download a version
 from the [`git-lfs` GitHub page](https://github.com/git-lfs/git-lfs), verify its checksum
 and checkout any LFS content.
-
-The configuration value `lfs_content_path_to_git_root` needs to be given despite the
-fact that this information could be retrieved with `git rev-parse --show-toplevel` in
-order to make the extension more robust against [recent build failures on ReadTheDocs](https://github.com/readthedocs/readthedocs.org/issues/8288).
 
 Additionally, a configuration value `lfs_content_post_commands` is available. It accepts a list
 of strings with commands that will be executed after the git-lfs checkout was performed.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,10 +34,6 @@ extensions = [
 
 # Configuration values specific to sphinx_lfs_content
 
-# This is the relative path from the location of conf.py to the git
-# repository root.
-lfs_content_path_to_git_root = ".."
-
 # These commands will be executed after the LFS checkout. This is just a test.
 lfs_content_post_commands = [
     "test $(wc -c test.png | awk '{print $1}') -eq 78713"


### PR DESCRIPTION
After recent fixes to the build process on readthedocs, this
parameter is not needed anymore. We issue a `SphinxWarning` if
it is set by the user.