### PR TITLE
Add Sphinx Extension classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "requests",
     ],
     classifiers=[
+        "Framework :: Sphinx :: Extension",
         "Programming Language :: Python :: 3",
         "Operating System :: Unix ",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).