### PR TITLE
Fix git-lfs version in adjusted PATH.

### DIFF
--- a/sphinx_lfs_content/__init__.py
+++ b/sphinx_lfs_content/__init__.py
@@ -35,7 +35,7 @@ def lfs_setup(_, config):
             # This works around a bug in git-lfs where git-lfs is called recursively,
             # but the inner calls rely on git-lfs being in PATH.
             env = os.environ
-            env["PATH"] = os.environ["PATH"] + os.path.pathsep + os.path.join(tmp_dir, "git-lfs-3.4.0")
+            env["PATH"] = os.environ["PATH"] + os.path.pathsep + os.path.join(tmp_dir, "git-lfs-3.4.1")
 
             # Fetch the LFS content of the repository
             subprocess.check_call("git-lfs install".split(), env=env)


### PR DESCRIPTION
Hi!

We use your plugin and noticed that our current doc builds fail since the git-lfs executable is missing. I think that's due to 3.4.1 being installed, but the PATH is still adjusted to include 3.4.0.

I fixed that in this PR (literally a 1 bit change, shortest PR I ever did :) ), and it should hopefully work now.

PS: I think this calls for a v1.1.6 release?