### PR TITLE
bug: fix git-lfs version in path

### DIFF
--- a/sphinx_lfs_content/__init__.py
+++ b/sphinx_lfs_content/__init__.py
@@ -35,7 +35,7 @@ def lfs_setup(_, config):
             # This works around a bug in git-lfs where git-lfs is called recursively,
             # but the inner calls rely on git-lfs being in PATH.
             env = os.environ
-            env["PATH"] = os.environ["PATH"] + os.path.pathsep + os.path.join(tmp_dir, "git-lfs-3.4.0")
+            env["PATH"] = os.environ["PATH"] + os.path.pathsep + os.path.join(tmp_dir, "git-lfs-3.4.1")
 
             # Fetch the LFS content of the repository
             subprocess.check_call("git-lfs install".split(), env=env)


### PR DESCRIPTION
`v1.1.5` runs into the follow error due to this bug.

```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/yatai/envs/latest/lib/python3.10/site-packages/sphinx/events.py", line 97, in emit
    results.append(listener.handler(self.app, *args))
  File "/home/docs/checkouts/readthedocs.org/user_builds/yatai/envs/latest/lib/python3.10/site-packages/sphinx_lfs_content/__init__.py", line 41, in lfs_setup
    subprocess.check_call("git-lfs install".split(), env=env)
  File "/home/docs/.asdf/installs/python/3.10.13/lib/python3.10/subprocess.py", line 364, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/home/docs/.asdf/installs/python/3.10.13/lib/python3.10/subprocess.py", line 345, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/home/docs/.asdf/installs/python/3.10.13/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/home/docs/.asdf/installs/python/3.10.13/lib/python3.10/subprocess.py", line 1863, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'git-lfs'
```